### PR TITLE
CircleCI Deploy to WP Repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,174 @@
+version: 2.1
+
+commands:
+  install_dependencies:
+    description: "Install development dependencies."
+    steps:
+      - run: composer install
+
+  mkdir_artifacts:
+    description: "Make Artifacts directory"
+    steps:
+      - run:
+          command: |
+            [ ! -d "/tmp/artifacts" ] && mkdir /tmp/artifacts &>/dev/null
+
+  set_verision_variable:
+    description: "Set the VERSION environment variable"
+    steps:
+      - run:
+          command: |
+            echo "export VERSION=$(grep 'Version:' /tmp/src/plugin.php | awk -F: '{print $2}' | sed 's/^\s//')" >> ${BASH_ENV}
+
+  show_pwd_info:
+    description: "Show information about the current directory"
+    steps:
+      - run: pwd
+      - run: ls -lash
+
+  svn_setup:
+    description: "Setup SVN"
+    steps:
+      - run: echo "export SLUG=$(grep '@package' /tmp/src/plugin.php | awk -F ' ' '{print $3}' | sed 's/^\s//')" >> ${BASH_ENV}
+      - run: svn co https://plugins.svn.wordpress.org/${SLUG} --depth=empty .
+      - run: svn up trunk
+      - run: svn up tags --depth=empty
+      - run: find ./trunk -not -path "./trunk" -delete
+      - run: cp -r /tmp/src/. ./trunk
+      - run: svn propset svn:ignore -F ./trunk/.svnignore ./trunk
+
+  svn_add_changes:
+    description: "Add changes to SVN"
+    steps:
+      - run:
+          command: if [[ ! -z $(svn st | grep ^\!) ]]; then svn st | grep ^! | awk '{print " --force "$2}' | xargs -0r svn rm; fi
+      - run: svn add --force .
+
+  svn_create_tag:
+    description: "Create a SVN tag"
+    steps:
+      - set_verision_variable
+      - run: svn cp trunk tags/${VERSION}
+
+  svn_commit:
+    description: "Commit changes to SVN"
+    steps:
+      - set_verision_variable
+      - run: svn ci -m "Tagging ${VERSION} from Github" --no-auth-cache --non-interactive --username "${SVN_USERNAME}" --password "${SVN_PASSWORD}"
+
+executors:
+  base:
+    docker:
+      - image: circleci/buildpack-deps:latest
+    working_directory: /tmp
+  php_node:
+    docker:
+      - image: circleci/php:7.3.3-stretch-node-browsers
+    working_directory: /tmp/src
+
+jobs:
+  checkout:
+    executor: base
+    steps:
+      - mkdir_artifacts
+      - checkout:
+          path: src
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - src
+
+  checks:
+    executor: php_node
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - install_dependencies
+      - run: composer phpcs
+
+  deploy_svn_branch:
+    executor: base
+    working_directory: /tmp/artifacts
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - svn_setup
+      - svn_add_changes
+      - svn_commit
+
+  deploy_svn_tag:
+    executor: base
+    working_directory: /tmp/artifacts
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - svn_setup
+      - svn_create_tag
+      - svn_add_changes
+      - svn_commit
+
+workflows:
+  version: 2
+  checks:
+    jobs:
+      - checkout:
+          filters:
+            branches:
+              ignore:
+                - master
+      - checks:
+          requires:
+            - checkout
+          filters:
+            branches:
+              ignore:
+                - master
+
+  branch_deploy:
+    jobs:
+      - checkout:
+          filters:
+            branches:
+              only:
+                - master
+      - checks:
+          requires:
+            - checkout
+          filters:
+            branches:
+              only:
+                - master
+      - deploy_svn_branch:
+          context: genesis-svn
+          requires:
+            - checks
+          filters:
+            branches:
+              only:
+                - master
+
+  tag_deploy:
+    jobs:
+      - checkout:
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
+      - checks:
+          requires:
+            - checkout
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
+      - deploy_svn_tag:
+          context: genesis-svn
+          requires:
+            - checks
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/

--- a/plugin.php
+++ b/plugin.php
@@ -1,17 +1,18 @@
 <?php
-/*
-
-Plugin Name: Genesis Author Pro
-Plugin URI: https://wordpress.org/plugins/genesis-author-pro/
-Description: Adds default Book CPT to any Genesis HTML5 theme.
-Version: 1.0.2
-Author: StudioPress
-Author URI: https://www.studiopress.com/
-Text Domain: genesis-author-pro
-Domain Path /languages/
-
-*/
-
+/**
+ *
+ * Plugin Name: Genesis Author Pro
+ * Plugin URI: https://wordpress.org/plugins/genesis-author-pro/
+ * Description: Adds default Book CPT to any Genesis HTML5 theme.
+ * Version: 1.0.2
+ * Author: StudioPress
+ * Author URI: https://www.studiopress.com/
+ * Text Domain: genesis-author-pro
+ * Domain Path /languages/
+ *
+ * @package genesis-author-pro
+ *
+ */
 if ( !defined( 'ABSPATH' ) ) {
 	die( "Sorry, you are not allowed to access this page directly." );
 }


### PR DESCRIPTION
This PR focuses on our CI/D automation efforts and allows for any merge into the `master` branch to be synced with `trunk` in the WP SVN Repo. It also allows for any `#.#.#` formatted tag to be deployed to the WP SVN Repo.

## Notes
- Added `@package` to, and adjusted docblock in `plugin.php` to prevent any errors in the CI/CD workflow
- Add `.circleci/config.yml` file